### PR TITLE
月途中の傾向からその月のコミット値を推測するフラグ追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ And execute the below command:
 ```
 go run ./main.go \
     --csv ~/Downloads/hourly_usage_extract_2020-07-27.csv \
-    --yyyymm 2020-08 \             # target year and month
+    --yyyymm 2020-10 \             # target year and month
     --commit-infrahost 60-80 \     # commit of Infrastructure Host (range)
     --commit-apmhost 5-10,20 \      # commit of APM Host (range)
     --commit-synthetics 10-30       # commit of synthetics (range)
@@ -23,6 +23,35 @@ go run ./main.go \
 ```
 
 ![](https://i.imgur.com/H5erEwQ.png)
+
+## サンプル
+
+2020-09-23 に 1年分の使用状況 (Usage) CSV をダウンロードし読み取り計算する。
+
+```
+go run ./main.go \
+    --csv ~/Downloads/hourly_usage_extract_2020-10-26.csv \
+    --commit-infrahost 50-100 \
+    --commit-apmhost 5-10 \
+    --commit-fargate-task 130-200 \
+    --commit-lambda-function 13-30 \
+    --commit-indexed-logs 10-45 \
+    --commit-analyzed-logs 0-35 \
+    --commit-synthetics-apitest 30-50 \
+    --predicted-as-month=true
+```
+
++---------------------+--------+----------------+
+|       SERVICE       | COMMIT | TOTAL COST ($) |
++---------------------+--------+----------------+
+| Infra Host          |     91 |        1278.99 |
+| APM Host            |      8 |         286.09 |
+| Fargate Task        |    150 |         180.04 |
+| Lambda Function     |     17 |         104.91 |
+| Indexed Logs        |     37 |          75.48 |
+| Analyzed Logs       |      0 |           0.00 |
+| Synthetics API Test |     35 |         213.75 |
++---------------------+--------+----------------+
 
 ## TODO
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ var (
 
 	targetYM string // yyyy-mm
 
+	predictedAsMonth bool
+
 	rangeCommitInfraHost         []float64
 	rangeCommitAPMHost           []float64
 	rangeCommitIndexedLogs       []float64
@@ -81,6 +83,7 @@ func init() {
 	flag.StringVarP(&commitAnalyzedLogs, "commit-analyzed-logs", "", "", "count of commit for analyzed logs")
 	flag.StringVarP(&fpath, "csv", "f", "", "csv file")
 	flag.StringVarP(&targetYM, "yyyymm", "t", "", "yyyy-mm")
+	flag.BoolVarP(&predictedAsMonth, "predicted-as-month", "p", true, "predict as a month even if in the middle of the moon")
 	flag.Parse()
 
 	if fpath == "" {
@@ -281,7 +284,11 @@ func handler() error {
 	// Indexed Logs --- start ---
 	totalPriceIndexedLogs := make([]float64, len(rangeCommitIndexedLogs))
 	for i, commit := range rangeCommitIndexedLogs {
-		excess := allIndexedLogs/1000_000*float64(endOfMonth.Day())/float64(lastDate.Day()) - commit
+		t := allIndexedLogs / 1000_000
+		if predictedAsMonth {
+			t = t * float64(endOfMonth.Day()) / float64(lastDate.Day())
+		}
+		excess := t - commit
 		if excess < 0 {
 			excess = 0
 		}
@@ -305,7 +312,11 @@ func handler() error {
 	// Analyzed Logs --- start ---
 	totalPriceAnalyzedLogs := make([]float64, len(rangeCommitAnalyzedLogs))
 	for i, commit := range rangeCommitAnalyzedLogs {
-		excess := allAnalyzedLogs/1000_000_000*float64(endOfMonth.Day())/float64(lastDate.Day()) - commit
+		t := allAnalyzedLogs / 1000_000_000
+		if predictedAsMonth {
+			t = t * float64(endOfMonth.Day()) / float64(lastDate.Day())
+		}
+		excess := t - commit
 		if excess < 0 {
 			excess = 0
 		}
@@ -329,7 +340,11 @@ func handler() error {
 	// Synthetics --- start ---
 	totalSyntheticsAPITest := make([]float64, len(rangeCommitSyntheticsAPITest))
 	for i, commit := range rangeCommitSyntheticsAPITest {
-		excess := allSyntheticsAPITest/10_000*float64(endOfMonth.Day())/float64(lastDate.Day()) - commit
+		t := allSyntheticsAPITest / 10_000
+		if predictedAsMonth {
+			t = t * float64(endOfMonth.Day()) / float64(lastDate.Day())
+		}
+		excess := t - commit
 		if excess < 0 {
 			excess = 0
 		}


### PR DESCRIPTION
月途中でその月の契約内容を更新することが多く、その月の使用状況からコミット値を推測できる様にします。